### PR TITLE
Add SystemInfo for WT and indecies

### DIFF
--- a/codegen/src/heap_size/mod.rs
+++ b/codegen/src/heap_size/mod.rs
@@ -1,0 +1,74 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Result, Type};
+
+pub fn expand(input: proc_macro2::TokenStream) -> Result<TokenStream> {
+    let input: DeriveInput = syn::parse2(input)?;
+    let name = &input.ident;
+
+    let body = match &input.data {
+        Data::Struct(data_struct) => {
+            let fields = match &data_struct.fields {
+                Fields::Named(fields_named) => fields_named.named.iter().collect::<Vec<_>>(),
+                Fields::Unnamed(fields_unnamed) => {
+                    fields_unnamed.unnamed.iter().collect::<Vec<_>>()
+                }
+                Fields::Unit => vec![],
+            };
+
+            if fields.is_empty() {
+                quote! { 0 }
+            } else if fields.iter().all(|f| is_copy_primitive(&f.ty)) {
+                quote! { std::mem::size_of::<Self>() }
+            } else {
+                let field_sizes = fields.iter().enumerate().map(|(i, f)| {
+                    let accessor = match &f.ident {
+                        Some(ident) => quote! { self.#ident },
+                        None => {
+                            let index = syn::Index::from(i);
+                            quote! { self.#index }
+                        }
+                    };
+                    quote! { size += #accessor.heap_size(); }
+                });
+
+                quote! {
+                    let mut size = 0;
+                    #(#field_sizes)*
+                    size
+                }
+            }
+        }
+        _ => {
+            return Err(syn::Error::new_spanned(
+                name,
+                "#[derive(HeapSize)] only supports structs",
+            ));
+        }
+    };
+
+    let t = quote! {
+        impl HeapSize for #name {
+            fn heap_size(&self) -> usize {
+                #body
+            }
+        }
+    };
+    println!("{}", t);
+    Ok(t)
+}
+
+fn is_copy_primitive(ty: &Type) -> bool {
+    matches!(
+        ty,
+        Type::Path(type_path)
+            if type_path.qself.is_none() &&
+               type_path.path.segments.len() == 1 &&
+               matches!(
+                   type_path.path.segments[0].ident.to_string().as_str(),
+                   "u8" | "u16" | "u32" | "u64" | "usize" |
+                   "i8" | "i16" | "i32" | "i64" | "isize" |
+                   "bool" | "char" | "f64" | "f32"
+               )
+    )
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,3 +1,4 @@
+mod heap_size;
 mod name_generator;
 mod persist_index;
 mod persist_table;
@@ -23,6 +24,13 @@ pub fn persist_index(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(PersistTable)]
 pub fn persist_table(input: TokenStream) -> TokenStream {
     persist_table::expand(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+#[proc_macro_derive(HeapSize)]
+pub fn heap_size(input: TokenStream) -> TokenStream {
+    heap_size::expand(input.into())
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/codegen/src/worktable/generator/index.rs
+++ b/codegen/src/worktable/generator/index.rs
@@ -47,11 +47,11 @@ impl Generator {
 
         let derive = if self.is_persist {
             quote! {
-                #[derive(Debug, Default, PersistIndex)]
+                #[derive(Debug, HeapSize, Default, PersistIndex)]
             }
         } else {
             quote! {
-                #[derive(Debug, Default)]
+                #[derive(Debug, HeapSize, Default)]
             }
         };
 

--- a/codegen/src/worktable/generator/row.rs
+++ b/codegen/src/worktable/generator/row.rs
@@ -96,7 +96,7 @@ impl Generator {
             .collect();
 
         quote! {
-            #[derive(rkyv::Archive, Debug, rkyv::Deserialize, Clone, rkyv::Serialize, PartialEq)]
+            #[derive(rkyv::Archive, Debug, rkyv::Deserialize, Clone, rkyv::Serialize, PartialEq, HeapSize)]
             #[rkyv(derive(Debug))]
             #[repr(C)]
             pub struct #ident {

--- a/codegen/src/worktable/generator/table/impls.rs
+++ b/codegen/src/worktable/generator/table/impls.rs
@@ -19,6 +19,7 @@ impl Generator {
         let iter_with_fn = self.gen_table_iter_with_fn();
         let iter_with_async_fn = self.gen_table_iter_with_async_fn();
         let count_fn = self.gen_table_count_fn();
+        let system_info_fn = self.gen_system_info_fn();
 
         quote! {
             impl #ident {
@@ -31,6 +32,7 @@ impl Generator {
                 #get_next_fn
                 #iter_with_fn
                 #iter_with_async_fn
+                #system_info_fn
             }
         }
     }
@@ -219,6 +221,14 @@ impl Generator {
             pub fn count(&self) -> Option<usize> {
                 let count = self.0.pk_map.len();
                 (count > 0).then_some(count)
+            }
+        }
+    }
+
+    fn gen_system_info_fn(&self) -> TokenStream {
+        quote! {
+            pub fn system_info(&self) -> SystemInfo {
+                self.0.system_info()
             }
         }
     }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,4 +13,4 @@ eyre = "0.6.12"
 futures = "0.3.30"
 async-std = "1.10"
 either = "1.15.0"
-
+ordered-float = "5.0.0"

--- a/examples/src/main.rs
+++ b/examples/src/main.rs
@@ -9,9 +9,9 @@ fn main() {
         columns: {
             id: u64 primary_key autoincrement,
             val: i64,
-            test: u8,
+            test: i32,
             attr: String,
-            attr2: i16,
+            attr2: i32,
             attr_float: f64,
             attr_string: String,
 
@@ -40,24 +40,38 @@ fn main() {
     // WT rows (has prefix My because of table name)
     let row = MyRow {
         val: 777,
-        attr: "Attribute1".to_string(),
+        attr: "Attribute0".to_string(),
         attr2: 345,
         test: 1,
         id: 0,
         attr_float: 100.0.into(),
-        attr_string: "String_attr".to_string(),
+        attr_string: "String_attr0".to_string(),
     };
+
+    for i in 2..100000 as i64 {
+        let row = MyRow {
+            val: 777,
+            attr: format!("Attribute{}", i),
+            attr2: 345 + i as i32,
+            test: i as i32,
+            id: i as u64,
+            attr_float: (100.0 + i as f64).into(),
+            attr_string: format!("String_attr{}", i),
+        };
+
+        my_table.insert(row).unwrap(); // или ? если ты внутри Result
+    }
 
     // insert
     let pk: MyPrimaryKey = my_table.insert(row).expect("primary key");
 
     // Select ALL records from WT
     let select_all = my_table.select_all().execute();
-    println!("Select All {:?}", select_all);
+    //println!("Select All {:?}", select_all);
 
     // Select All records with attribute TEST
     let select_all = my_table.select_all().execute();
-    println!("Select All {:?}", select_all);
+    //println!("Select All {:?}", select_all);
 
     // Select by Idx
     let select_by_attr = my_table
@@ -65,20 +79,24 @@ fn main() {
         .execute()
         .unwrap();
 
-    for row in select_by_attr {
-        println!("Select by idx, row {:?}", row);
-    }
+    //for row in select_by_attr {
+    //    println!("Select by idx, row {:?}", row);
+    //}
 
     // Update Value query
     let update = my_table.update_val_by_id(ValByIdQuery { val: 1337 }, pk.clone());
     let _ = block_on(update);
 
     let select_all = my_table.select_all().execute();
-    println!("Select after update val {:?}", select_all);
+    //println!("Select after update val {:?}", select_all);
 
     let delete = my_table.delete(pk);
     let _ = block_on(delete);
 
     let select_all = my_table.select_all().execute();
-    println!("Select after delete {:?}", select_all);
+    //println!("Select after delete {:?}", select_all);
+
+    let info = my_table.system_info();
+
+    println!("{}", info.pretty());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod prelude {
     };
     pub use crate::primary_key::{PrimaryKeyGenerator, PrimaryKeyGeneratorState, TablePrimaryKey};
     pub use crate::table::select::{Order, QueryParams, SelectQueryBuilder, SelectQueryExecutor};
+    pub use crate::table::system_info::{HeapSize, SystemInfo};
     pub use crate::util::{OrderedF32Def, OrderedF64Def};
     pub use crate::{
         lock::Lock, Difference, IndexMap, IndexMultiMap, TableIndex, TableIndexCdc, TableRow,
@@ -45,7 +46,7 @@ pub mod prelude {
 
     pub use derive_more::{From, Into};
     pub use lockfree::set::Set as LockFreeSet;
-    pub use worktable_codegen::{PersistIndex, PersistTable};
+    pub use worktable_codegen::{HeapSize, PersistIndex, PersistTable};
 
     pub const WT_INDEX_EXTENSION: &str = ".wt.idx";
     pub const WT_DATA_EXTENSION: &str = ".wt.data";

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,4 +1,5 @@
 pub mod select;
+pub mod system_info;
 
 use std::marker::PhantomData;
 

--- a/src/table/system_info.rs
+++ b/src/table/system_info.rs
@@ -1,0 +1,232 @@
+use data_bucket::Link;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::in_memory::{RowWrapper, StorableRow};
+use crate::{IndexMap, IndexMultiMap, WorkTable};
+
+#[derive(Debug)]
+pub struct SystemInfo {
+    pub table_name: &'static str,
+    pub page_count: usize,
+    pub row_count: usize,
+    pub empty_slots: u64,
+    pub memory_usage_bytes: u64,
+    pub idx_size: usize,
+}
+
+pub trait HeapSize {
+    fn heap_size(&self) -> usize;
+}
+
+impl<T: HeapSize> HeapSize for Option<T> {
+    fn heap_size(&self) -> usize {
+        self.as_ref().map_or(0, |v| v.heap_size())
+    }
+}
+
+impl<T: HeapSize> HeapSize for Vec<T> {
+    fn heap_size(&self) -> usize {
+        self.capacity() * std::mem::size_of::<T>()
+            + self.iter().map(|v| v.heap_size()).sum::<usize>()
+    }
+}
+
+impl HeapSize for String {
+    fn heap_size(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl<T, V> HeapSize for IndexMap<T, V>
+where
+    T: Ord + Clone + 'static + HeapSize + std::marker::Send,
+    V: Ord + Clone + 'static + HeapSize + std::marker::Send,
+{
+    fn heap_size(&self) -> usize {
+        let mut size = std::mem::size_of_val(self);
+
+        for (k, v) in self.iter() {
+            size += k.heap_size();
+            size += v.heap_size();
+        }
+
+        size
+    }
+}
+
+impl<T, V> HeapSize for IndexMultiMap<T, V>
+where
+    T: Ord + Clone + 'static + HeapSize + std::marker::Send,
+    V: Ord + Clone + 'static + HeapSize + std::marker::Send,
+{
+    fn heap_size(&self) -> usize {
+        let mut size = std::mem::size_of_val(self);
+
+        for (k, v) in self.iter() {
+            size += k.heap_size();
+            size += v.heap_size();
+        }
+
+        size
+    }
+}
+
+impl HeapSize for Link {
+    fn heap_size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
+}
+
+impl<T: HeapSize> HeapSize for Box<T> {
+    fn heap_size(&self) -> usize {
+        std::mem::size_of::<T>() + (**self).heap_size()
+    }
+}
+
+impl<T: HeapSize> HeapSize for Arc<T> {
+    fn heap_size(&self) -> usize {
+        std::mem::size_of::<T>() + (**self).heap_size()
+    }
+}
+
+impl<T: HeapSize> HeapSize for Rc<T> {
+    fn heap_size(&self) -> usize {
+        std::mem::size_of::<T>() + (**self).heap_size()
+    }
+}
+
+impl<K: HeapSize + Eq + std::hash::Hash, V: HeapSize> HeapSize for HashMap<K, V> {
+    fn heap_size(&self) -> usize {
+        let mut size = 0;
+        for (k, v) in self.iter() {
+            size += k.heap_size();
+            size += v.heap_size();
+        }
+        size
+    }
+}
+
+impl HeapSize for u8 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for u16 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for u32 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for i32 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for u64 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for i64 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for f64 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for f32 {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for usize {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for isize {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for bool {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+impl HeapSize for char {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+
+impl<
+        Row,
+        PrimaryKey,
+        AvailableTypes,
+        SecondaryIndexes: HeapSize,
+        LockType,
+        PkGen,
+        const DATA_LENGTH: usize,
+    > WorkTable<Row, PrimaryKey, AvailableTypes, SecondaryIndexes, LockType, PkGen, DATA_LENGTH>
+where
+    PrimaryKey: Clone + Ord + Send + 'static + std::hash::Hash,
+    Row: StorableRow,
+    <Row as StorableRow>::WrappedRow: RowWrapper<Row>,
+{
+    pub fn system_info(&self) -> SystemInfo {
+        let page_count = self.data.get_page_count();
+        let row_count = self.pk_map.len();
+
+        let empty_links = self.data.get_empty_links().len();
+
+        let bytes = self.data.get_bytes();
+
+        let memory_usage_bytes = bytes
+            .iter()
+            .map(|(_buf, free_offset)| *free_offset as u64)
+            .sum();
+
+        let idx_size = self.indexes.heap_size();
+
+        SystemInfo {
+            table_name: self.table_name,
+            page_count,
+            row_count,
+            empty_slots: empty_links as u64,
+            memory_usage_bytes,
+            idx_size,
+        }
+    }
+}
+
+impl SystemInfo {
+    pub fn pretty(&self) -> String {
+        let mem_kb = self.memory_usage_bytes as f64 / 1024.0;
+        let idx_kb = self.idx_size as f64 / 1024.0;
+
+        format!(
+            "\
+|| Table: {}\n\
+|| Rows: {} ({} pages, {} empty slots)\n\
+|| Memory: {:.2} KB (data) + {:.2} KB (indexes)\n\
+|| Total: {:.2} KB",
+            self.table_name,
+            self.row_count,
+            self.page_count,
+            self.empty_slots,
+            mem_kb,
+            idx_kb,
+            mem_kb + idx_kb,
+        )
+    }
+}


### PR DESCRIPTION
Counts data and indecies size 

```rust 
let info = table.system_info();
println!("{}", info.pretty());

|| Table: My
|| Rows: 9999998 (63208 pages, 1 empty slots)
|| Memory: 1014185.14 KB (data) + 681425.38 KB (indexes)
|| Total: 1695610.52 KB

```


